### PR TITLE
Add /f/imacron kern

### DIFF
--- a/sources/Lexend.glyphs
+++ b/sources/Lexend.glyphs
@@ -57035,6 +57035,7 @@ idieresis = 50;
 idieresisacute = 50;
 igrave = 40;
 iinvertedbreve = 50;
+imacron = 40;
 parenright = 30;
 slash = -20;
 };


### PR DESCRIPTION
I thought “fī” looked a little too close. I wasn't sure what kern value to use, but this looked good to me. (I'm rather illiterate about type design, so if there's a way to determine the best value, please let me know.)

<img width="64" alt="f-imacron-before" src="https://user-images.githubusercontent.com/54900/99668329-3e9e4780-2a76-11eb-8322-42552cdd04b3.png"> <img width="66" alt="f-imacron-after40" src="https://user-images.githubusercontent.com/54900/99668336-40680b00-2a76-11eb-9aee-2db0935421bb.png">

