### PR TITLE
added venv, and autosave to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+venv
+*(Autosaved)*


### PR DESCRIPTION
venv in .gitignore allows us to use virtual environments without adding them to our history
autosave prevents us from adding autosaved glyphs files to the project history